### PR TITLE
Set depth module parameters

### DIFF
--- a/config/rs_cam.yaml
+++ b/config/rs_cam.yaml
@@ -5,6 +5,9 @@
       rgb_camera:
         profile: '640,480,60'
         enable_auto_exposure: false
+      depth_module:
+        enable_auto_exposure: false
+        profile: '640,480,60'
       enable_depth: false
       enable_infra: false
       enable_infra1: false

--- a/config/rs_cam.yaml
+++ b/config/rs_cam.yaml
@@ -6,8 +6,8 @@
         profile: '640,480,60'
         enable_auto_exposure: false
       depth_module:
-        enable_auto_exposure: false
         profile: '640,480,60'
+        enable_auto_exposure: false
       enable_depth: false
       enable_infra: false
       enable_infra1: false


### PR DESCRIPTION
This PR does the following:

* Sets depth module profile to 640,480,60, matching that of the color stream
* Disables depth module auto-exposure