### PR TITLE
Fix aloha_static->aloha_stationary

### DIFF
--- a/aloha/robot_utils.py
+++ b/aloha/robot_utils.py
@@ -255,12 +255,12 @@ def disable_gravity_compensation(bot: InterbotixManipulatorXS):
     gravity_compensation.disable()
 
 
-def load_yaml_file(config_type: str = "robot", name: str = "aloha_static", base_path: str = None) -> dict:
+def load_yaml_file(config_type: str = "robot", name: str = "aloha_stationary", base_path: str = None) -> dict:
     """
     Loads configuration from a YAML file based on the specified type and name.
 
     :param config_type: Type of configuration to load, e.g., 'robot' or 'task'. Defaults to 'robot'.
-    :param name: Name of the robot or task configuration to load. Defaults to 'aloha_static' for robots.
+    :param name: Name of the robot or task configuration to load. Defaults to 'aloha_stationary' for robots.
     :return: The loaded configuration as a dictionary.
     :raises FileNotFoundError: Raised if the specified configuration file does not exist.
     :raises RuntimeError: Raised if there is an error loading the YAML file.

--- a/launch/aloha_bringup.launch.py
+++ b/launch/aloha_bringup.launch.py
@@ -359,8 +359,8 @@ def generate_launch_description():
     declared_arguments.append(
         DeclareLaunchArgument(
             "robot",
-            default_value="aloha_static",
-            description="Name of the robot configuration file (e.g., aloha_static, aloha_solo, aloha_mobile)",
+            default_value="aloha_stationary",
+            description="Name of the robot configuration file (e.g., aloha_stationary, aloha_solo, aloha_mobile)",
         )
     )
 

--- a/package.xml
+++ b/package.xml
@@ -10,6 +10,7 @@
   <buildtool_depend>ament_python</buildtool_depend>
 
   <depend>interbotix_common_modules</depend>
+  <depend>interbotix_gravity_compensation</depend>
   <depend>interbotix_ros_slate</depend>
   <depend>interbotix_xs_modules</depend>
   <depend>interbotix_xs_msgs</depend>

--- a/scripts/record_episodes.py
+++ b/scripts/record_episodes.py
@@ -450,7 +450,7 @@ def main(args: Dict[str, any]) -> None:
     :param args: Dictionary of arguments, expected keys:
         - "enable_base_torque" (bool): Whether to enable torque on the base (for mobile robots).
         - "gravity_compensation" (bool): Whether to enable gravity compensation for leader robots.
-        - "robot" (str): Robot setup configuration (e.g., 'aloha_solo', 'aloha_static', 'aloha_mobile').
+        - "robot" (str): Robot setup configuration (e.g., 'aloha_solo', 'aloha_stationary', 'aloha_mobile').
         - "task_name" (str): Task name used to fetch specific task configuration.
         - "episode_idx" (Optional[int]): Episode index for dataset naming; if None, auto-indexing is used.
     """
@@ -552,7 +552,7 @@ if __name__ == "__main__":
         "--robot",
         action="store",
         type=str,
-        help="Robot setup configuration (e.g., aloha_solo, aloha_static, aloha_mobile).",
+        help="Robot setup configuration (e.g., aloha_solo, aloha_stationary, aloha_mobile).",
         required=True,
     )
 

--- a/scripts/replay_episodes.py
+++ b/scripts/replay_episodes.py
@@ -33,7 +33,7 @@ def main(args: Dict[str, any]) -> None:
     :param args: Dictionary of command-line arguments, including:
         - 'dataset_dir' (str): Path to the directory containing episode datasets.
         - 'episode_idx' (int): Index of the episode file to load.
-        - 'robot' (str): Robot configuration name (e.g., 'aloha_solo', 'aloha_static', 'aloha_mobile').
+        - 'robot' (str): Robot configuration name (e.g., 'aloha_solo', 'aloha_stationary', 'aloha_mobile').
     """
     # Load robot configuration
     robot_base = args.get('robot', '')
@@ -135,7 +135,7 @@ if __name__ == '__main__':
         '-r', '--robot',
         action='store',
         type=str,
-        help='Robot configuration name (e.g., aloha_solo, aloha_static, aloha_mobile).',
+        help='Robot configuration name (e.g., aloha_solo, aloha_stationary, aloha_mobile).',
         required=True,
     )
 

--- a/scripts/sleep.py
+++ b/scripts/sleep.py
@@ -36,7 +36,7 @@ def main() -> None:
     argparser.add_argument(
         '-r', '--robot',
         required=True,
-        help='Specify the robot configuration to use: aloha_solo, aloha_static, or aloha_mobile.'
+        help='Specify the robot configuration to use: aloha_solo, aloha_stationary, or aloha_mobile.'
     )
     args = argparser.parse_args()
 

--- a/scripts/teleop.py
+++ b/scripts/teleop.py
@@ -246,6 +246,6 @@ if __name__ == '__main__':
     parser.add_argument(
         '-r', '--robot',
         required=True,
-        help='Specify the robot configuration to use: aloha_solo, aloha_static, or aloha_mobile.'
+        help='Specify the robot configuration to use: aloha_solo, aloha_stationary, or aloha_mobile.'
     )
     main(vars(parser.parse_args()))

--- a/scripts/visualize_episodes.py
+++ b/scripts/visualize_episodes.py
@@ -316,7 +316,7 @@ if __name__ == '__main__':
     parser.add_argument(
         '-r', '--robot',
         required=True,
-        help='Specify the robot configuration to use: aloha_solo, aloha_static, or aloha_mobile.'
+        help='Specify the robot configuration to use: aloha_solo, aloha_stationary, or aloha_mobile.'
     )
 
     parser.add_argument('--ismirror', action='store_true')


### PR DESCRIPTION
This PR fixes the name of the bimanual robot from `aloha_static` to `aloha_stationary` to match the actual configuration names.